### PR TITLE
feat(youtube): prevent multiple videos from playing simultaneously

### DIFF
--- a/components/youtube-embed.tsx
+++ b/components/youtube-embed.tsx
@@ -1,19 +1,92 @@
+import { useEffect, useRef } from "react";
+
+// Add type definitions above the existing code
+interface YouTubePlayer {
+  pauseVideo: () => void;
+}
+
+interface YTPlayerEvent {
+  data: number;
+}
+
+declare global {
+  interface Window {
+    YT: {
+      Player: new (
+        element: HTMLElement,
+        options: { events: { onStateChange: (event: YTPlayerEvent) => void } }
+      ) => YouTubePlayer;
+      PlayerState: {
+        PLAYING: number;
+      };
+    };
+    onYouTubeIframeAPIReady: () => void;
+  }
+}
+
+// Modify the global array to use YouTubePlayer type
+let youtubePlayers: YouTubePlayer[] = [];
+
 interface YoutubeEmbedProps {
-  videoId: string
-  title: string
+  videoId: string;
+  title: string;
 }
 
 export function YoutubeEmbed({ videoId, title }: YoutubeEmbedProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    let player: YouTubePlayer | undefined;
+
+    const loadPlayer = () => {
+      if (!iframeRef.current) return;
+      player = new window.YT.Player(iframeRef.current, {
+        events: {
+          onStateChange: (event: YTPlayerEvent) => {
+            if (event.data === window.YT.PlayerState.PLAYING) {
+              youtubePlayers.forEach((p) => {
+                if (p !== player && typeof p.pauseVideo === "function") {
+                  p.pauseVideo();
+                }
+              });
+            }
+          },
+        },
+      });
+      youtubePlayers.push(player);
+    };
+
+    if (window.YT && window.YT.Player) {
+      loadPlayer();
+    } else {
+      const previousCallback = window.onYouTubeIframeAPIReady;
+      window.onYouTubeIframeAPIReady = function () {
+        if (previousCallback) previousCallback();
+        loadPlayer();
+      };
+      if (!document.getElementById("youtube-iframe-api")) {
+        const tag = document.createElement("script");
+        tag.id = "youtube-iframe-api";
+        tag.src = "https://www.youtube.com/iframe_api";
+        document.body.appendChild(tag);
+      }
+    }
+
+    return () => {
+      youtubePlayers = youtubePlayers.filter((p) => p !== player);
+    };
+  }, []);
+
   return (
     <div className="aspect-video overflow-hidden rounded-md">
       <iframe
+        ref={iframeRef}
         className="w-full h-full"
-        src={`https://www.youtube.com/embed/${videoId}`}
+        src={`https://www.youtube.com/embed/${videoId}?enablejsapi=1`}
         title={title}
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen
       ></iframe>
     </div>
-  )
+  );
 }
-


### PR DESCRIPTION
## Description

- This commit integrates the `YouTube IFrame API`  into our `YoutubeEmbed` component to ensure that only one video plays at a time. 
- This change improves the user experience by stopping overlapping audio.


## Video 

#### Before: 

https://github.com/user-attachments/assets/71a92586-8c0f-4ba9-a545-cce94ea1337c


#### After: 

https://github.com/user-attachments/assets/1b83033b-13cb-46a1-89a1-256b1c688564



